### PR TITLE
Adds an error message if a package.json file is missing.

### DIFF
--- a/lib/getJson.js
+++ b/lib/getJson.js
@@ -10,6 +10,7 @@ module.exports = function (pth, cb) {
       });
     }
     else {
+      console.error(`Unable to find package.json at '${pkgjson}'`)
       cb(null, null); // no error but no package.json
     }
   });


### PR DESCRIPTION
Addresses #65 to give a more clear error message if a package.json file is missing.